### PR TITLE
Don't inherit EventTarget in partial interface Navigator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -68,6 +68,7 @@ urlPrefix: http://www.w3.org/TR/uievents-code/#code-; type: dfn; spec: uievents-
 	<h3 id="navigator-interface">Navigator Interface</h3>
 
 		<pre class="idl" data-highlight="webidl">
+		[Exposed=Window]
 		partial interface Navigator {
 			[SecureContext, SameObject] readonly attribute Keyboard keyboard;
 		};

--- a/index.bs
+++ b/index.bs
@@ -68,7 +68,7 @@ urlPrefix: http://www.w3.org/TR/uievents-code/#code-; type: dfn; spec: uievents-
 	<h3 id="navigator-interface">Navigator Interface</h3>
 
 		<pre class="idl" data-highlight="webidl">
-		partial interface Navigator : EventTarget {
+		partial interface Navigator {
 			[SecureContext, SameObject] readonly attribute Keyboard keyboard;
 		};
 		</pre>


### PR DESCRIPTION
This is not valid Web IDL.